### PR TITLE
Allow swagger-servant-ui with redoc to be nested in an API

### DIFF
--- a/servant-swagger-ui-redoc/redoc.index.html.tmpl
+++ b/servant-swagger-ui-redoc/redoc.index.html.tmpl
@@ -7,9 +7,17 @@
     <style>
       body { margin: 0; padding: 0; }
     </style>
+    <script>
+        // Force Strict-URL Routing for assets relative paths
+        (function onload() {
+            if (!window.location.href.endsWith("/")) {
+                window.location.href += "/";
+            }
+        }());
+    </script>
   </head>
   <body>
-    <redoc spec-url='/SERVANT_SWAGGER_UI_SCHEMA'></redoc>
+    <redoc spec-url='../SERVANT_SWAGGER_UI_SCHEMA'></redoc>
     <script src="redoc.min.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
In the current state, if we were to declare a servant-swagger-ui server behind some path, for instance:

    type API =
        "docs" :> ServantSwaggerUI "swagger-ui" "swagger.json"

One would correctly have access to the template in `<host>/docs/swagger.ui` but the template would refer to a swagger.json at `/swagger.json` whereas it is hosted under `/docs/swagger.json`. To cope with this, we can use relative paths in the template, making sure that the current url is always ending with a slash.
Note also that without a trailing slash, it will fail at loading assets like the initial `redoc.min.hs` bundle, so it is rather important to enforce strict URL-routing here.

