### PR TITLE
Allow custom servers for the Swagger spec file

### DIFF
--- a/servant-swagger-ui-core/src/Servant/Swagger/UI/Core.hs
+++ b/servant-swagger-ui-core/src/Servant/Swagger/UI/Core.hs
@@ -42,6 +42,7 @@ module Servant.Swagger.UI.Core (
     -- * Implementation details
     SwaggerUiHtml(..),
     swaggerSchemaUIServerImpl,
+    swaggerSchemaUIServerImpl',
     Handler,
     ) where
 
@@ -103,7 +104,14 @@ swaggerSchemaUIServerImpl
     :: (Server api ~ Handler Swagger)
     => T.Text -> [(FilePath, ByteString)]
     -> Swagger -> Server (SwaggerSchemaUI' dir api)
-swaggerSchemaUIServerImpl indexTemplate files swagger = return swagger
+swaggerSchemaUIServerImpl indexTemplate files swagger
+  = swaggerSchemaUIServerImpl' indexTemplate files $ return swagger
+
+swaggerSchemaUIServerImpl'
+    :: T.Text -> [(FilePath, ByteString)]
+    -> Server api -> Server (SwaggerSchemaUI' dir api)
+swaggerSchemaUIServerImpl' indexTemplate files server
+       = server
     :<|> return (SwaggerUiHtml indexTemplate)
     :<|> return (SwaggerUiHtml indexTemplate)
     :<|> rest

--- a/servant-swagger-ui-jensoleg/src/Servant/Swagger/UI/JensOleG.hs
+++ b/servant-swagger-ui-jensoleg/src/Servant/Swagger/UI/JensOleG.hs
@@ -46,6 +46,7 @@ module Servant.Swagger.UI.JensOleG (
     SwaggerSchemaUI,
     SwaggerSchemaUI',
     jensolegSwaggerSchemaUIServer,
+    jensolegSwaggerSchemaUIServer',
 
     -- ** ReDoc theme
     jensolegIndexTemplate,
@@ -70,6 +71,12 @@ jensolegSwaggerSchemaUIServer
     => Swagger -> Server (SwaggerSchemaUI' dir api)
 jensolegSwaggerSchemaUIServer =
     swaggerSchemaUIServerImpl jensolegIndexTemplate jensolegFiles
+
+-- | Use a custom server to serve the Swagger spec source.
+jensolegSwaggerSchemaUIServer'
+    :: Server api -> Server (SwaggerSchemaUI' dir api)
+jensolegSwaggerSchemaUIServer' =
+    swaggerSchemaUIServerImpl' jensolegIndexTemplate jensolegFiles
 
 jensolegIndexTemplate :: Text
 jensolegIndexTemplate = $(embedText "jensoleg.index.html.tmpl")

--- a/servant-swagger-ui-redoc/src/Servant/Swagger/UI/ReDoc.hs
+++ b/servant-swagger-ui-redoc/src/Servant/Swagger/UI/ReDoc.hs
@@ -46,6 +46,7 @@ module Servant.Swagger.UI.ReDoc (
     SwaggerSchemaUI,
     SwaggerSchemaUI',
     redocSchemaUIServer,
+    redocSchemaUIServer',
 
     -- ** ReDoc theme
     redocIndexTemplate,
@@ -68,6 +69,13 @@ redocSchemaUIServer
     => Swagger -> Server (SwaggerSchemaUI' dir api)
 redocSchemaUIServer =
     swaggerSchemaUIServerImpl redocIndexTemplate redocFiles
+
+-- | Use a custom server to serve the Swagger spec source.
+redocSchemaUIServer'
+    :: Server api -> Server (SwaggerSchemaUI' dir api)
+redocSchemaUIServer' =
+    swaggerSchemaUIServerImpl' redocIndexTemplate redocFiles
+
 
 redocIndexTemplate :: Text
 redocIndexTemplate = $(embedText "redoc.index.html.tmpl")

--- a/servant-swagger-ui/src/Servant/Swagger/UI.hs
+++ b/servant-swagger-ui/src/Servant/Swagger/UI.hs
@@ -46,6 +46,7 @@ module Servant.Swagger.UI (
     SwaggerSchemaUI,
     SwaggerSchemaUI',
     swaggerSchemaUIServer,
+    swaggerSchemaUIServer',
 
     -- ** Official swagger ui
     swaggerUiIndexTemplate,
@@ -70,6 +71,17 @@ swaggerSchemaUIServer
     => Swagger -> Server (SwaggerSchemaUI' dir api)
 swaggerSchemaUIServer =
     swaggerSchemaUIServerImpl swaggerUiIndexTemplate swaggerUiFiles
+
+-- | Use a custom server to serve the Swagger spec source.
+--
+-- This allows even more control over how the spec source is served.
+-- It allows, for instance, serving the spec source with authentication,
+-- customizing the response based on the client or serving a swagger.yaml
+-- instead.
+swaggerSchemaUIServer'
+    :: Server api -> Server (SwaggerSchemaUI' dir api)
+swaggerSchemaUIServer' =
+    swaggerSchemaUIServerImpl' swaggerUiIndexTemplate swaggerUiFiles
 
 swaggerUiIndexTemplate :: Text
 swaggerUiIndexTemplate = $(embedText "index.html.tmpl")


### PR DESCRIPTION
The point of this PR:
```
-- | Use a custom server to serve the Swagger spec source.
--
-- This allows even more control over how the spec source is served.
-- It allows, for instance, serving the spec source with authentication,
-- customizing the response based on the client or serving a swagger.yaml
-- instead.
swaggerSchemaUIServer'
    :: Server api -> Server (SwaggerSchemaUI' dir api)
swaggerSchemaUIServer' =
    swaggerSchemaUIServerImpl' swaggerUiIndexTemplate swaggerUiFiles
```