### PR TITLE
Generalise over the Swagger datatype rebase

### DIFF
--- a/servant-swagger-ui-core/Changelog.md
+++ b/servant-swagger-ui-core/Changelog.md
@@ -1,3 +1,20 @@
+# 0.3.6
+
+- Generalize to support arbitrary type instead of hardcoded `Value`.
+
+  `SwaggerSchemaUI` now needs one more parameter which typically is
+  either `Swagger` or `OpenApi`.
+
+  To migrate from older version, alter your API type from
+  `SwaggerSchemaUI "swagger-ui" "swagger.json"`
+  to
+  `SwaggerSchemaUI "swagger-ui" "swagger.json" Swagger`
+
+  Or in case of the more generic variant, old
+  `SwaggerSchemaUI' "foo-ui" ("foo" :> "swagger.json" :> Get '[JSON] Value)`
+  becomes
+  `SwaggerSchemaUI' "foo-ui" ("foo" :> "swagger.json" :> Get '[JSON] Swagger)`
+
 # 0.3.5
 
 - Generalize `SwaggerSchemaUI` and `swaggerSchemaUIServerImpl` to support arbitrary `Value` instead

--- a/servant-swagger-ui-core/servant-swagger-ui-core.cabal
+++ b/servant-swagger-ui-core/servant-swagger-ui-core.cabal
@@ -40,13 +40,10 @@ library
     , aeson                >=0.8.0.2  && <2.3
     , blaze-markup         >=0.7.0.2  && <0.9
     , bytestring           >=0.10.4.0 && <0.12
-    , http-media           >=0.7.1.3  && <0.9
-    , servant              >=0.14     && <0.21
+    , servant              >=0.14     && <0.20
     , servant-blaze        >=0.8      && <0.10
     , servant-server       >=0.14     && <0.21
     , text                 >=1.2.3.0  && <2.1
-    , transformers         >=0.3      && <0.7
-    , transformers-compat  >=0.3      && <0.8
     , wai-app-static       >=3.0.1.1  && <3.2
 
   exposed-modules:  Servant.Swagger.UI.Core

--- a/servant-swagger-ui-core/servant-swagger-ui-core.cabal
+++ b/servant-swagger-ui-core/servant-swagger-ui-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.12
 name:               servant-swagger-ui-core
-version:            0.3.5
+version:            0.3.6
 synopsis:           Servant swagger ui core components
 category:           Web, Servant, Swagger
 description:

--- a/servant-swagger-ui-core/servant-swagger-ui-core.cabal
+++ b/servant-swagger-ui-core/servant-swagger-ui-core.cabal
@@ -36,14 +36,14 @@ library
   hs-source-dirs:   src
   ghc-options:      -Wall
   build-depends:
-      base                 >=4.7      && <4.19
+      base                 >=4.7      && <4.20
     , aeson                >=0.8.0.2  && <2.3
     , blaze-markup         >=0.7.0.2  && <0.9
-    , bytestring           >=0.10.4.0 && <0.12
-    , servant              >=0.14     && <0.20
+    , bytestring           >=0.10.4.0 && <0.13
+    , servant              >=0.14     && <0.21
     , servant-blaze        >=0.8      && <0.10
     , servant-server       >=0.14     && <0.21
-    , text                 >=1.2.3.0  && <2.1
+    , text                 >=1.2.3.0  && <2.2
     , wai-app-static       >=3.0.1.1  && <3.2
 
   exposed-modules:  Servant.Swagger.UI.Core

--- a/servant-swagger-ui-example/servant-swagger-ui-example.cabal
+++ b/servant-swagger-ui-example/servant-swagger-ui-example.cabal
@@ -30,7 +30,7 @@ executable servant-swagger-ui-example
   ghc-options:      -threaded
   build-depends:
       aeson                        >=0.8.0.2  && <2.3
-    , base                         >=4.7      && <4.19
+    , base                         >=4.7      && <4.20
     , base-compat                  >=0.9.3    && <0.14
     , lens                         >=4.7.0.1  && <5.3
     , servant

--- a/servant-swagger-ui-example/src/Main.hs
+++ b/servant-swagger-ui-example/src/Main.hs
@@ -136,13 +136,13 @@ type BasicAPI = Get '[PlainText, JSON] Text
 
 type API =
     -- this serves both: swagger.json and swagger-ui
-    SwaggerSchemaUI "swagger-ui" "swagger.json"
+    SwaggerSchemaUI "swagger-ui" "swagger.json" Swagger
     :<|> BasicAPI
 
 -- To test nested case
 type API' = API
     :<|> "nested" :> API
-    :<|> SwaggerSchemaUI' "foo-ui" ("foo" :> "swagger.json" :> Get '[JSON] Value)
+    :<|> SwaggerSchemaUI' "foo-ui" ("foo" :> "swagger.json" :> Get '[JSON] Swagger)
 
 -- Implementation
 
@@ -174,7 +174,7 @@ server' uiFlavour = server Normal
         -- Unfortunately we have to specify the basePath manually atm.
 
     schemaUiServer
-        :: (Server api ~ Handler Value)
+        :: (Server api ~ Handler Swagger)
         => Swagger -> Server (SwaggerSchemaUI' dir api)
     schemaUiServer = case uiFlavour of
         Original -> swaggerSchemaUIServer

--- a/servant-swagger-ui-jensoleg/servant-swagger-ui-jensoleg.cabal
+++ b/servant-swagger-ui-jensoleg/servant-swagger-ui-jensoleg.cabal
@@ -85,13 +85,13 @@ library
   ghc-options:      -Wall
   build-depends:    servant-swagger-ui-core >=0.3.6 && <0.4
   build-depends:
-      base             >=4.7      && <4.19
+      base             >=4.7      && <4.20
     , aeson            >=0.8.0.2  && <2.3
-    , bytestring       >=0.10.4.0 && <0.12
+    , bytestring       >=0.10.4.0 && <0.13
     , file-embed-lzma  >=0        && <0.1
     , servant          >=0.14     && <0.21
     , servant-server   >=0.14     && <0.21
-    , text             >=1.2.3.0  && <2.1
+    , text             >=1.2.3.0  && <2.2
 
   exposed-modules:  Servant.Swagger.UI.JensOleG
   default-language: Haskell2010

--- a/servant-swagger-ui-jensoleg/servant-swagger-ui-jensoleg.cabal
+++ b/servant-swagger-ui-jensoleg/servant-swagger-ui-jensoleg.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.12
 name:               servant-swagger-ui-jensoleg
-version:            0.3.4
+version:            0.3.6
 synopsis:           Servant swagger ui: Jens-Ole Graulund theme
 category:           Web, Servant, Swagger
 description:
@@ -83,7 +83,7 @@ source-repository head
 library
   hs-source-dirs:   src
   ghc-options:      -Wall
-  build-depends:    servant-swagger-ui-core >=0.3.5 && <0.4
+  build-depends:    servant-swagger-ui-core >=0.3.6 && <0.4
   build-depends:
       base             >=4.7      && <4.19
     , aeson            >=0.8.0.2  && <2.3

--- a/servant-swagger-ui-jensoleg/src/Servant/Swagger/UI/JensOleG.hs
+++ b/servant-swagger-ui-jensoleg/src/Servant/Swagger/UI/JensOleG.hs
@@ -55,7 +55,6 @@ module Servant.Swagger.UI.JensOleG (
 
 import Servant.Swagger.UI.Core
 
-import Data.Aeson      (ToJSON, Value)
 import Data.ByteString (ByteString)
 import Data.Text       (Text)
 import FileEmbedLzma
@@ -67,7 +66,7 @@ import Servant
 --
 -- See <https://github.com/jensoleg/swagger-ui>
 jensolegSwaggerSchemaUIServer
-    :: (Server api ~ Handler Value, ToJSON a)
+    :: (Server api ~ Handler a)
     => a -> Server (SwaggerSchemaUI' dir api)
 jensolegSwaggerSchemaUIServer =
     swaggerSchemaUIServerImpl jensolegIndexTemplate jensolegFiles

--- a/servant-swagger-ui-redoc/CHANGELOG.md
+++ b/servant-swagger-ui-redoc/CHANGELOG.md
@@ -1,3 +1,19 @@
+- 0.3.6.1.22.3
+    - Generalize to support arbitrary type instead of hardcoded `Value`.
+
+      `SwaggerSchemaUI` now needs one more parameter which typically is
+      either `Swagger` or `OpenApi`.
+
+      To migrate from older version, alter your API type from
+      `SwaggerSchemaUI "swagger-ui" "swagger.json"`
+      to
+      `SwaggerSchemaUI "swagger-ui" "swagger.json" Swagger`
+
+      Or in case of the more generic variant, old
+      `SwaggerSchemaUI' "foo-ui" ("foo" :> "swagger.json" :> Get '[JSON] Value)`
+      becomes
+      `SwaggerSchemaUI' "foo-ui" ("foo" :> "swagger.json" :> Get '[JSON] Swagger)`
+
 - 0.3.2.1.22.3
     - Update to ReDoc-1.22.3
 

--- a/servant-swagger-ui-redoc/servant-swagger-ui-redoc.cabal
+++ b/servant-swagger-ui-redoc/servant-swagger-ui-redoc.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.12
 name:               servant-swagger-ui-redoc
-version:            0.3.4.1.22.3
+version:            0.3.6.1.22.3
 synopsis:           Servant swagger ui: ReDoc theme
 category:           Web, Servant, Swagger
 description:
@@ -37,7 +37,7 @@ source-repository head
 library
   hs-source-dirs:   src
   ghc-options:      -Wall
-  build-depends:    servant-swagger-ui-core >=0.3.5 && <0.4
+  build-depends:    servant-swagger-ui-core >=0.3.6 && <0.4
   build-depends:
       base             >=4.7      && <4.19
     , aeson            >=0.8.0.2  && <2.3

--- a/servant-swagger-ui-redoc/servant-swagger-ui-redoc.cabal
+++ b/servant-swagger-ui-redoc/servant-swagger-ui-redoc.cabal
@@ -39,13 +39,13 @@ library
   ghc-options:      -Wall
   build-depends:    servant-swagger-ui-core >=0.3.6 && <0.4
   build-depends:
-      base             >=4.7      && <4.19
+      base             >=4.7      && <4.20
     , aeson            >=0.8.0.2  && <2.3
-    , bytestring       >=0.10.4.0 && <0.12
+    , bytestring       >=0.10.4.0 && <0.13
     , file-embed-lzma  >=0        && <0.1
     , servant          >=0.14     && <0.21
     , servant-server   >=0.14     && <0.21
-    , text             >=1.2.3.0  && <2.1
+    , text             >=1.2.3.0  && <2.2
 
   exposed-modules:  Servant.Swagger.UI.ReDoc
   default-language: Haskell2010

--- a/servant-swagger-ui-redoc/src/Servant/Swagger/UI/ReDoc.hs
+++ b/servant-swagger-ui-redoc/src/Servant/Swagger/UI/ReDoc.hs
@@ -57,7 +57,6 @@ module Servant.Swagger.UI.ReDoc (
 
 import Servant.Swagger.UI.Core
 
-import Data.Aeson      (ToJSON, Value)
 import Data.ByteString (ByteString)
 import Data.Text       (Text)
 import FileEmbedLzma
@@ -67,7 +66,7 @@ import Servant
 --
 -- See <https://github.com/Rebilly/ReDoc/tree/v1.x>
 redocSchemaUIServer
-    :: (Server api ~ Handler Value, ToJSON a)
+    :: (Server api ~ Handler a)
     => a -> Server (SwaggerSchemaUI' dir api)
 redocSchemaUIServer =
     swaggerSchemaUIServerImpl redocIndexTemplate redocFiles
@@ -80,7 +79,7 @@ redocSchemaUIServer =
 -- redocSchemaUIServerT :: Swagger -> ServerT (SwaggerSchemaUI schema dir) m
 -- @
 redocSchemaUIServerT
-    :: (Monad m, ServerT api m ~ m Value, ToJSON a)
+    :: (Monad m, ServerT api m ~ m a)
     => a -> ServerT (SwaggerSchemaUI' dir api) m
 redocSchemaUIServerT =
     swaggerSchemaUIServerImpl redocIndexTemplate redocFiles

--- a/servant-swagger-ui/CHANGELOG.md
+++ b/servant-swagger-ui/CHANGELOG.md
@@ -1,3 +1,19 @@
+- 0.3.6.4.14.0
+    - Generalize to support arbitrary type instead of hardcoded `Value`.
+
+      `SwaggerSchemaUI` now needs one more parameter which typically is
+      either `Swagger` or `OpenApi`.
+
+      To migrate from older version, alter your API type from
+      `SwaggerSchemaUI "swagger-ui" "swagger.json"`
+      to
+      `SwaggerSchemaUI "swagger-ui" "swagger.json" Swagger`
+
+      Or in case of the more generic variant, old
+      `SwaggerSchemaUI' "foo-ui" ("foo" :> "swagger.json" :> Get '[JSON] Value)`
+      becomes
+      `SwaggerSchemaUI' "foo-ui" ("foo" :> "swagger.json" :> Get '[JSON] Swagger)`
+
 - 0.3.5.4.14.0
     - Update to `swagger-ui-4.14.0`
 

--- a/servant-swagger-ui/servant-swagger-ui.cabal
+++ b/servant-swagger-ui/servant-swagger-ui.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.12
 name:               servant-swagger-ui
-version:            0.3.5.5.0.0
+version:            0.3.6.4.14.0
 synopsis:           Servant swagger ui
 category:           Web, Servant, Swagger
 description:
@@ -53,7 +53,7 @@ source-repository head
 library
   hs-source-dirs:   src
   ghc-options:      -Wall
-  build-depends:    servant-swagger-ui-core >=0.3.5 && <0.4
+  build-depends:    servant-swagger-ui-core >=0.3.6 && <0.4
   build-depends:
       base             >=4.7      && <4.19
     , aeson            >=0.8.0.2  && <2.3

--- a/servant-swagger-ui/servant-swagger-ui.cabal
+++ b/servant-swagger-ui/servant-swagger-ui.cabal
@@ -55,13 +55,13 @@ library
   ghc-options:      -Wall
   build-depends:    servant-swagger-ui-core >=0.3.6 && <0.4
   build-depends:
-      base             >=4.7      && <4.19
+      base             >=4.7      && <4.20
     , aeson            >=0.8.0.2  && <2.3
-    , bytestring       >=0.10.4.0 && <0.12
+    , bytestring       >=0.10.4.0 && <0.13
     , file-embed-lzma  >=0        && <0.1
     , servant          >=0.14     && <0.21
     , servant-server   >=0.14     && <0.21
-    , text             >=1.2.3.0  && <2.1
+    , text             >=1.2.3.0  && <2.2
 
   exposed-modules:  Servant.Swagger.UI
   default-language: Haskell2010

--- a/servant-swagger-ui/src/Servant/Swagger/UI.hs
+++ b/servant-swagger-ui/src/Servant/Swagger/UI.hs
@@ -62,7 +62,6 @@ module Servant.Swagger.UI (
 
 import Servant.Swagger.UI.Core
 
-import Data.Aeson      (ToJSON, Value)
 import Data.ByteString (ByteString)
 import Data.Text       (Text)
 import FileEmbedLzma
@@ -75,7 +74,7 @@ import Servant
 -- swaggerSchemaUIServer :: OpenApi -> Server (SwaggerSchemaUI schema dir)
 -- @
 swaggerSchemaUIServer
-    :: (Server api ~ Handler Value, ToJSON a)
+    :: (Server api ~ Handler a)
     => a -> Server (SwaggerSchemaUI' dir api)
 swaggerSchemaUIServer =
     swaggerSchemaUIServerImpl swaggerUiIndexTemplate swaggerUiFiles
@@ -89,7 +88,7 @@ swaggerSchemaUIServer =
 -- swaggerSchemaUIServerT :: OpenApi -> ServerT (SwaggerSchemaUI schema dir) m
 -- @
 swaggerSchemaUIServerT
-    :: (Monad m, ServerT api m ~ m Value, ToJSON a)
+    :: (Monad m, ServerT api m ~ m a)
     => a -> ServerT (SwaggerSchemaUI' dir api) m
 swaggerSchemaUIServerT =
     swaggerSchemaUIServerImpl swaggerUiIndexTemplate swaggerUiFiles


### PR DESCRIPTION
See #89 

Rebased, added Changelog entries and version bumps. Provided it is pretty straightforward to upgrade I don't think it's worth bothering with additional complexity.

@kosmikus Thanks for hunting down the ordering issues. Using this in combination with https://github.com/biocad/openapi3/pull/27 it's almost there except for openapi examples that still need `Value`s.