### PR TITLE
Force lexicographic ordering on swagger json.

### DIFF
--- a/servant-swagger-ui-core/servant-swagger-ui-core.cabal
+++ b/servant-swagger-ui-core/servant-swagger-ui-core.cabal
@@ -36,6 +36,7 @@ library
   build-depends:
       base                 >=4.7      && <4.16
     , aeson                >=0.8.0.2  && <2.1.0
+    , aeson-pretty         >=0.8.0    && <0.9
     , blaze-markup         >=0.7.0.2  && <0.9
     , bytestring           >=0.10.4.0 && <0.12
     , http-media           >=0.7.1.3  && <0.9

--- a/servant-swagger-ui-core/src/Servant/Swagger/UI/Core.hs
+++ b/servant-swagger-ui-core/src/Servant/Swagger/UI/Core.hs
@@ -38,6 +38,7 @@ module Servant.Swagger.UI.Core (
     -- * Swagger UI API
     SwaggerSchemaUI,
     SwaggerSchemaUI',
+    PrettyJSON, 
 
     -- * Implementation details
     SwaggerUiHtml(..),
@@ -74,8 +75,8 @@ import qualified Data.Text as T
 type SwaggerSchemaUI (dir :: Symbol) (schema :: Symbol) =
     SwaggerSchemaUI' dir (schema :> Get '[PrettyJSON] Value)
 
--- Private servant content type to force pretty-printing and thus lexicographic order of json
--- fields.  The order is honored by the UI.
+-- Servant content type to force pretty-printing and lexicographic order of json
+-- fields.  (The order in the serialized JSON object is honored by the UI.)
 data PrettyJSON
 
 instance MimeRender PrettyJSON Value where


### PR DESCRIPTION
The orderings of end-points and definitions are taken from the serialized json object.  Lexicographic may not always be what you would want, but it is better than what we have now, which in the case of old aeson renderings based in `HashMap` is completely random.

The only downside I can see is performance, which really shouldn't be an issue on this end-point.

One question remains whether I should export PrettyJSON.  It doesn't really belong here, but we are exporting type aliases that make use of it, so some sophisticated uses may be blocked if we don't.