### PR TITLE
Allow newer deps (used in Nightly), add 9.0 CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.0.2
+            compilerKind: ghc
+            compilerVersion: 9.0.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
             compilerVersion: 8.10.7
@@ -199,16 +204,6 @@ jobs:
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           echo "package servant-swagger-ui-redoc" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
-          cat >> cabal.project <<EOF
-          allow-newer: swagger2:base
-          allow-newer: swagger2:lens
-          allow-newer: swagger2:optics-core
-          allow-newer: swagger2:optics-th
-          allow-newer: swagger2:template-haskell
-          allow-newer: servant-swagger:base
-          allow-newer: servant-swagger:lens
-          allow-newer: servant-swagger:Cabal
-          EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(servant-swagger-ui|servant-swagger-ui-core|servant-swagger-ui-example|servant-swagger-ui-jensoleg|servant-swagger-ui-redoc)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -260,8 +255,8 @@ jobs:
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.19.*' all
       - name: constraint set servant-0.18
         run: |
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.18.*' --dependencies-only -j2 all
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.18.*' all
+          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.18.*' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.18.*' all ; fi
       - name: constraint set servant-0.17
         run: |
           if [ $((HCNUMVER < 81000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.17.*' --dependencies-only -j2 all ; fi

--- a/cabal.project
+++ b/cabal.project
@@ -4,6 +4,3 @@ packages:
   servant-swagger-ui-example/
   servant-swagger-ui-jensoleg/
   servant-swagger-ui-redoc/
-
-allow-newer: swagger2:base, swagger2:lens, swagger2:optics-core, swagger2:optics-th, swagger2:template-haskell
-allow-newer: servant-swagger:base, servant-swagger:lens, servant-swagger:Cabal

--- a/servant-swagger-ui-core/servant-swagger-ui-core.cabal
+++ b/servant-swagger-ui-core/servant-swagger-ui-core.cabal
@@ -22,6 +22,7 @@ tested-with:
   GHC ==8.6.5
    || ==8.8.4
    || ==8.10.7
+   || ==9.0.2
 
 extra-source-files: Changelog.md
 
@@ -34,14 +35,14 @@ library
   ghc-options:      -Wall
   build-depends:
       base                 >=4.7      && <4.16
-    , aeson                >=0.8.0.2  && <1.6
+    , aeson                >=0.8.0.2  && <2.1.0
     , blaze-markup         >=0.7.0.2  && <0.9
-    , bytestring           >=0.10.4.0 && <0.11
+    , bytestring           >=0.10.4.0 && <0.12
     , http-media           >=0.7.1.3  && <0.9
     , servant              >=0.14     && <0.20
     , servant-blaze        >=0.8      && <0.10
     , servant-server       >=0.14     && <0.20
-    , text                 >=1.2.3.0  && <1.3
+    , text                 >=1.2.3.0  && <2.1
     , transformers         >=0.3      && <0.6
     , transformers-compat  >=0.3      && <0.7
     , wai-app-static       >=3.0.1.1  && <3.2

--- a/servant-swagger-ui-example/servant-swagger-ui-example.cabal
+++ b/servant-swagger-ui-example/servant-swagger-ui-example.cabal
@@ -17,6 +17,7 @@ tested-with:
   GHC ==8.6.5
    || ==8.8.4
    || ==8.10.7
+   || ==9.0.2
 
 source-repository head
   type:     git
@@ -26,9 +27,9 @@ executable servant-swagger-ui-example
   main-is:          Main.hs
   ghc-options:      -threaded
   build-depends:
-      aeson                        >=0.8.0.2  && <1.6
+      aeson                        >=0.8.0.2  && <2.1.0
     , base                         >=4.7      && <4.16
-    , base-compat                  >=0.9.3    && <0.12
+    , base-compat                  >=0.9.3    && <0.13
     , lens                         >=4.7.0.1  && <5.2
     , servant
     , servant-server

--- a/servant-swagger-ui-jensoleg/servant-swagger-ui-jensoleg.cabal
+++ b/servant-swagger-ui-jensoleg/servant-swagger-ui-jensoleg.cabal
@@ -6,7 +6,7 @@ category:           Web, Servant, Swagger
 description:
   Provide embedded swagger UI for servant and swagger (i.e. servant-swagger)
   .
-  Jsn-Ole Graulund theme https://github.com/jensoleg/swagger-org
+  Jens-Ole Graulund theme https://github.com/jensoleg/swagger-org
 
 homepage:           https://github.com/haskell-servant/servant-swagger-ui
 bug-reports:
@@ -21,6 +21,7 @@ tested-with:
   GHC ==8.6.5
    || ==8.8.4
    || ==8.10.7
+   || ==9.0.2
 
 extra-source-files:
   jensoleg.index.html.tmpl
@@ -83,12 +84,12 @@ library
   build-depends:    servant-swagger-ui-core >=0.3.5 && <0.4
   build-depends:
       base             >=4.7      && <4.16
-    , aeson            >=0.8.0.2  && <1.6
-    , bytestring       >=0.10.4.0 && <0.11
+    , aeson            >=0.8.0.2  && <2.1.0
+    , bytestring       >=0.10.4.0 && <0.12
     , file-embed-lzma  >=0        && <0.1
     , servant          >=0.14     && <0.20
     , servant-server   >=0.14     && <0.20
-    , text             >=1.2.3.0  && <1.3
+    , text             >=1.2.3.0  && <2.1
 
   exposed-modules:  Servant.Swagger.UI.JensOleG
   default-language: Haskell2010

--- a/servant-swagger-ui-redoc/servant-swagger-ui-redoc.cabal
+++ b/servant-swagger-ui-redoc/servant-swagger-ui-redoc.cabal
@@ -21,6 +21,7 @@ tested-with:
   GHC ==8.6.5
    || ==8.8.4
    || ==8.10.7
+   || ==9.0.2
 
 extra-source-files:
   redoc-dist-1.22.3/redoc.min.js
@@ -37,12 +38,12 @@ library
   build-depends:    servant-swagger-ui-core >=0.3.5 && <0.4
   build-depends:
       base             >=4.7      && <4.16
-    , aeson            >=0.8.0.2  && <1.6
-    , bytestring       >=0.10.4.0 && <0.11
+    , aeson            >=0.8.0.2  && <2.1.0
+    , bytestring       >=0.10.4.0 && <0.12
     , file-embed-lzma  >=0        && <0.1
     , servant          >=0.14     && <0.20
     , servant-server   >=0.14     && <0.20
-    , text             >=1.2.3.0  && <1.3
+    , text             >=1.2.3.0  && <2.1
 
   exposed-modules:  Servant.Swagger.UI.ReDoc
   default-language: Haskell2010

--- a/servant-swagger-ui/servant-swagger-ui.cabal
+++ b/servant-swagger-ui/servant-swagger-ui.cabal
@@ -21,6 +21,7 @@ tested-with:
   GHC ==8.6.5
    || ==8.8.4
    || ==8.10.7
+   || ==9.0.2
 
 extra-source-files:
   CHANGELOG.md
@@ -47,12 +48,12 @@ library
   build-depends:    servant-swagger-ui-core >=0.3.5 && <0.4
   build-depends:
       base             >=4.7      && <4.16
-    , aeson            >=0.8.0.2  && <1.6
-    , bytestring       >=0.10.4.0 && <0.11
+    , aeson            >=0.8.0.2  && <2.1.0
+    , bytestring       >=0.10.4.0 && <0.12
     , file-embed-lzma  >=0        && <0.1
     , servant          >=0.14     && <0.20
     , servant-server   >=0.14     && <0.20
-    , text             >=1.2.3.0  && <1.3
+    , text             >=1.2.3.0  && <2.1
 
   exposed-modules:  Servant.Swagger.UI
   default-language: Haskell2010


### PR DESCRIPTION
This is a subset of #97, and it just focuses on allowing some newer libraries, and adding a CI run just for GHC 9.0. I think this should be less controversial since no allow-newers are needed at all. This will also enable compatibility with Stackage Nightly as requested by @domenkozar .

As can be seen from the CI build logs, it does use Aeson 2.0.3.0 to build. But it doesn't use the newer bytestring or text yet. This is because haskell-servant/servant/pull/1526 hasn't been released to Hackage yet. But when it does, everything will continue to work seamlessly as can be demonstrated with this command:

    cabal build all --constraint='bytestring>=0.11' --constraint='aeson>=2' --constraint='text>=2' --allow-newer=servant-server:text,servant:text,servant-swagger:bytestring,servant-swagger:text -w ghc-9.0.2