### PR TITLE
Allow servant-0.20 and other newer deps

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.6.2
+            compilerKind: ghc
+            compilerVersion: 9.6.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.4.5
             compilerKind: ghc
             compilerVersion: 9.4.5
@@ -256,10 +261,14 @@ jobs:
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local
+      - name: constraint set servant-0.20
+        run: |
+          if [ $((HCNUMVER >= 81000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.20.*' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 81000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.20.*' all ; fi
       - name: constraint set servant-0.19
         run: |
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.19.*' --dependencies-only -j2 all
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.19.*' all
+          if [ $((HCNUMVER < 90600)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.19.*' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER < 90600)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.19.*' all ; fi
       - name: constraint set servant-0.18
         run: |
           if [ $((HCNUMVER < 90000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.18.*' --dependencies-only -j2 all ; fi

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -15,3 +15,7 @@ constraint-set servant-0.18
 constraint-set servant-0.19
   ghc: >= 8.6 && <9.6
   constraints: servant ==0.19.*
+
+constraint-set servant-0.20
+  ghc: >= 8.10 && <9.8
+  constraints: servant ==0.20.*

--- a/servant-swagger-ui-core/servant-swagger-ui-core.cabal
+++ b/servant-swagger-ui-core/servant-swagger-ui-core.cabal
@@ -24,6 +24,7 @@ tested-with:
    || ==9.0.2
    || ==9.2.7
    || ==9.4.5
+   || ==9.6.2
 
 extra-source-files: Changelog.md
 
@@ -35,14 +36,14 @@ library
   hs-source-dirs:   src
   ghc-options:      -Wall
   build-depends:
-      base                 >=4.7      && <4.18
+      base                 >=4.7      && <4.19
     , aeson                >=0.8.0.2  && <2.2
     , blaze-markup         >=0.7.0.2  && <0.9
     , bytestring           >=0.10.4.0 && <0.12
     , http-media           >=0.7.1.3  && <0.9
-    , servant              >=0.14     && <0.20
+    , servant              >=0.14     && <0.21
     , servant-blaze        >=0.8      && <0.10
-    , servant-server       >=0.14     && <0.20
+    , servant-server       >=0.14     && <0.21
     , text                 >=1.2.3.0  && <2.1
     , transformers         >=0.3      && <0.7
     , transformers-compat  >=0.3      && <0.8

--- a/servant-swagger-ui-example/servant-swagger-ui-example.cabal
+++ b/servant-swagger-ui-example/servant-swagger-ui-example.cabal
@@ -19,6 +19,7 @@ tested-with:
    || ==9.0.2
    || ==9.2.7
    || ==9.4.5
+   || ==9.6.2
 
 source-repository head
   type:     git
@@ -29,8 +30,8 @@ executable servant-swagger-ui-example
   ghc-options:      -threaded
   build-depends:
       aeson                        >=0.8.0.2  && <2.2
-    , base                         >=4.7      && <4.18
-    , base-compat                  >=0.9.3    && <0.13
+    , base                         >=4.7      && <4.19
+    , base-compat                  >=0.9.3    && <0.14
     , lens                         >=4.7.0.1  && <5.3
     , servant
     , servant-server

--- a/servant-swagger-ui-jensoleg/servant-swagger-ui-jensoleg.cabal
+++ b/servant-swagger-ui-jensoleg/servant-swagger-ui-jensoleg.cabal
@@ -23,6 +23,7 @@ tested-with:
    || ==9.0.2
    || ==9.2.7
    || ==9.4.5
+   || ==9.6.2
 
 extra-source-files:
   jensoleg.index.html.tmpl
@@ -84,12 +85,12 @@ library
   ghc-options:      -Wall
   build-depends:    servant-swagger-ui-core >=0.3.5 && <0.4
   build-depends:
-      base             >=4.7      && <4.18
+      base             >=4.7      && <4.19
     , aeson            >=0.8.0.2  && <2.2
     , bytestring       >=0.10.4.0 && <0.12
     , file-embed-lzma  >=0        && <0.1
-    , servant          >=0.14     && <0.20
-    , servant-server   >=0.14     && <0.20
+    , servant          >=0.14     && <0.21
+    , servant-server   >=0.14     && <0.21
     , text             >=1.2.3.0  && <2.1
 
   exposed-modules:  Servant.Swagger.UI.JensOleG

--- a/servant-swagger-ui-redoc/servant-swagger-ui-redoc.cabal
+++ b/servant-swagger-ui-redoc/servant-swagger-ui-redoc.cabal
@@ -23,6 +23,7 @@ tested-with:
    || ==9.0.2
    || ==9.2.7
    || ==9.4.5
+   || ==9.6.2
 
 extra-source-files:
   redoc-dist-1.22.3/redoc.min.js
@@ -38,12 +39,12 @@ library
   ghc-options:      -Wall
   build-depends:    servant-swagger-ui-core >=0.3.5 && <0.4
   build-depends:
-      base             >=4.7      && <4.18
+      base             >=4.7      && <4.19
     , aeson            >=0.8.0.2  && <2.2
     , bytestring       >=0.10.4.0 && <0.12
     , file-embed-lzma  >=0        && <0.1
-    , servant          >=0.14     && <0.20
-    , servant-server   >=0.14     && <0.20
+    , servant          >=0.14     && <0.21
+    , servant-server   >=0.14     && <0.21
     , text             >=1.2.3.0  && <2.1
 
   exposed-modules:  Servant.Swagger.UI.ReDoc

--- a/servant-swagger-ui/servant-swagger-ui.cabal
+++ b/servant-swagger-ui/servant-swagger-ui.cabal
@@ -23,6 +23,7 @@ tested-with:
    || ==9.0.2
    || ==9.2.7
    || ==9.4.5
+   || ==9.6.2
 
 extra-source-files:
   CHANGELOG.md
@@ -54,12 +55,12 @@ library
   ghc-options:      -Wall
   build-depends:    servant-swagger-ui-core >=0.3.5 && <0.4
   build-depends:
-      base             >=4.7      && <4.18
+      base             >=4.7      && <4.19
     , aeson            >=0.8.0.2  && <2.2
     , bytestring       >=0.10.4.0 && <0.12
     , file-embed-lzma  >=0        && <0.1
-    , servant          >=0.14     && <0.20
-    , servant-server   >=0.14     && <0.20
+    , servant          >=0.14     && <0.21
+    , servant-server   >=0.14     && <0.21
     , text             >=1.2.3.0  && <2.1
 
   exposed-modules:  Servant.Swagger.UI


### PR DESCRIPTION
Tested using

```
$ for i in servant-swagger-ui*; do (cd $i; cabal outdated); done
All dependencies are up to date.
All dependencies are up to date.
All dependencies are up to date.
All dependencies are up to date.
All dependencies are up to date.
$ cabal build --enable-tests --allow-newer=servant-blaze:servant -c 'base-compat>=0.13' all
```

There are no tests to run.


Depends on:

* https://github.com/haskell-servant/servant-blaze/pull/23
