### PR TITLE
Pull Joachim Breitner's dep bumper fixes

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: cache cabal store
-        uses: actions/cache@v3
+      - name: Cache cabal store
+        id: cache
+        uses: actions/cache/restore@v3
         with:
           key: bump-action-cabal-store-${{ runner.os }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -97,6 +98,13 @@ jobs:
         continue-on-error: true
         run: |
           cabal build --only-dependencies --enable-tests --write-ghc-environment-files=always ${{ env.CABAL_FLAGS }}
+
+      - name: Save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+          path: ~/.cabal/store
 
       - name: Build local package
         if: env.CABAL_COUNT > 0 && steps.dependency-build.outcome == 'success'

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -91,27 +91,29 @@ jobs:
           echo "$DELIMITER" >> $GITHUB_ENV
 
       - name: Build dependencies
+        id: dependency-build
         if: env.CABAL_COUNT > 0
         shell: bash
+        continue-on-error: true
         run: |
           cabal build --only-dependencies --enable-tests --write-ghc-environment-files=always ${{ env.CABAL_FLAGS }}
 
       - name: Build local package
-        if: env.CABAL_COUNT > 0
+        if: env.CABAL_COUNT > 0 && steps.dependency-build.outcome == 'success'
         shell: bash
         run: |
           cabal build --enable-tests --write-ghc-environment-files=always ${{ env.CABAL_FLAGS }}
           cabal test ${{ env.CABAL_FLAGS }}
 
       - name: Fetch cabal-plan-bounds
-        if: env.CABAL_COUNT > 0
+        if: env.CABAL_COUNT > 0 && steps.dependency-build.outcome == 'success'
         shell: bash
         run: |
           curl -L https://github.com/nomeata/cabal-plan-bounds/releases/latest/download/cabal-plan-bounds.linux.gz | gunzip  > /usr/local/bin/cabal-plan-bounds
           chmod +x /usr/local/bin/cabal-plan-bounds
 
       - name: Update .cabal file
-        if: env.CABAL_COUNT > 0
+        if: env.CABAL_COUNT > 0 && steps.dependency-build.outcome == 'success'
         shell: bash
         run: |
           # This line was added just for servant-swagger-ui, and counter-acts the default
@@ -122,7 +124,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        if: env.CABAL_COUNT > 0
+        if: env.CABAL_COUNT > 0 && steps.dependency-build.outcome == 'success'
         uses: peter-evans/create-pull-request@v5
         with:
           branch: "cabal-updates"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -90,8 +90,13 @@ jobs:
           cabal outdated >> $GITHUB_ENV
           echo "$DELIMITER" >> $GITHUB_ENV
 
+      - name: Build dependencies
+        if: env.CABAL_COUNT > 0
+        shell: bash
+        run: |
+          cabal build --dependencies only --enable-tests --write-ghc-environment-files=always ${{ env.CABAL_FLAGS }}
 
-      - name: Build
+      - name: Build local package
         if: env.CABAL_COUNT > 0
         shell: bash
         run: |

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -94,7 +94,7 @@ jobs:
         if: env.CABAL_COUNT > 0
         shell: bash
         run: |
-          cabal build --dependencies only --enable-tests --write-ghc-environment-files=always ${{ env.CABAL_FLAGS }}
+          cabal build --only-dependencies --enable-tests --write-ghc-environment-files=always ${{ env.CABAL_FLAGS }}
 
       - name: Build local package
         if: env.CABAL_COUNT > 0


### PR DESCRIPTION
This allows the dep bumper to not report a failure when it fails building a dependency of servant-swagger-ui-core with allow-newer.