### PR TITLE
Fix deps bumper

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: cache cabal store
-        uses: actions/cache@v3
+      - name: Cache cabal store
+        id: cache
+        uses: actions/cache/restore@v3
         with:
           key: bump-action-cabal-store-${{ runner.os }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -97,6 +98,13 @@ jobs:
         continue-on-error: true
         run: |
           cabal build --only-dependencies --enable-tests --write-ghc-environment-files=always ${{ env.CABAL_FLAGS }}
+
+      - name: Save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+          path: ~/.cabal/store
 
       - name: Build local package
         if: env.CABAL_COUNT > 0 && steps.dependency-build.outcome == 'success'

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -91,27 +91,29 @@ jobs:
           echo "$DELIMITER" >> $GITHUB_ENV
 
       - name: Build dependencies
+        id: dependency-build
         if: env.CABAL_COUNT > 0
         shell: bash
+        continue-on-error: true
         run: |
           cabal build --only-dependencies --enable-tests --write-ghc-environment-files=always ${{ env.CABAL_FLAGS }}
 
       - name: Build local package
-        if: env.CABAL_COUNT > 0
+        if: env.CABAL_COUNT > 0 && steps.dependency-build.outcome == 'success'
         shell: bash
         run: |
           cabal build --enable-tests --write-ghc-environment-files=always ${{ env.CABAL_FLAGS }}
           cabal test ${{ env.CABAL_FLAGS }}
 
       - name: Fetch cabal-plan-bounds
-        if: env.CABAL_COUNT > 0
+        if: env.CABAL_COUNT > 0 && steps.dependency-build.outcome == 'success'
         shell: bash
         run: |
           curl -L https://github.com/nomeata/cabal-plan-bounds/releases/latest/download/cabal-plan-bounds.linux.gz | gunzip  > /usr/local/bin/cabal-plan-bounds
           chmod +x /usr/local/bin/cabal-plan-bounds
 
       - name: Update .cabal file
-        if: env.CABAL_COUNT > 0
+        if: env.CABAL_COUNT > 0 && steps.dependency-build.outcome == 'success'
         shell: bash
         run: |
           # This line was added just for servant-swagger-ui, and counter-acts the default
@@ -122,7 +124,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        if: env.CABAL_COUNT > 0
+        if: env.CABAL_COUNT > 0 && steps.dependency-build.outcome == 'success'
         uses: peter-evans/create-pull-request@v5
         with:
           branch: "cabal-updates"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -90,8 +90,13 @@ jobs:
           cabal outdated >> $GITHUB_ENV
           echo "$DELIMITER" >> $GITHUB_ENV
 
+      - name: Build dependencies
+        if: env.CABAL_COUNT > 0
+        shell: bash
+        run: |
+          cabal build --dependencies only --enable-tests --write-ghc-environment-files=always ${{ env.CABAL_FLAGS }}
 
-      - name: Build
+      - name: Build local package
         if: env.CABAL_COUNT > 0
         shell: bash
         run: |

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,3 +1,4 @@
+# Based on nomeata's dep bumper, should go back to using that when it supports executing build-tzdata.sh after checkout
 name: Create dependency bump PR
 on:
   # allows manual triggering from https://github.com/../../actions/workflows/bump.yml
@@ -13,5 +14,125 @@ permissions:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./servant-swagger-ui-core
     steps:
-    - uses: nomeata/haskell-bounds-bump-action@main
+      - uses: actions/checkout@v3
+
+      - name: cache cabal store
+        uses: actions/cache@v3
+        with:
+          key: bump-action-cabal-store-${{ runner.os }}-${{ github.sha }}
+          path: ~/.cabal/store
+          restore-keys: bump-action-cabal-store-${{ runner.os }}-
+
+      - uses: haskell/actions/setup@v2
+        with:
+          ghc-version: latest
+
+      - name: Run cabal outdated
+        shell: bash
+        run: |
+          cabal outdated
+
+          # also remember the values and the number of changes
+          echo 'Output of `cabal outdated`:' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cabal outdated  >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          DELIMITER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "CABAL_OUTDATED<<$DELIMITER" >> $GITHUB_ENV
+          cabal outdated | tail -n +2 | sort | uniq >> $GITHUB_ENV
+          echo "$DELIMITER" >> $GITHUB_ENV
+
+          echo "CABAL_COUNT<<$DELIMITER" >> $GITHUB_ENV
+          cabal outdated | tail -n +2 | sort | uniq | wc -l >> $GITHUB_ENV
+          echo "$DELIMITER" >> $GITHUB_ENV
+
+          echo "CABAL_FLAGS<<$DELIMITER" >> $GITHUB_ENV
+          cabal outdated | tail -n +2 | sort | uniq |
+            perl -ne 'print "--allow-newer=*:$1 --constraint=$1==$2 " if /([a-zA-Z0-9-]*).*\(latest: (.*)\)/' >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo "$DELIMITER" >> $GITHUB_ENV
+
+      - name: Gather PR description
+        if: env.CABAL_COUNT > 0
+        shell: bash
+        run: |
+          DELIMITER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "GIT_PR_TITLE<<$DELIMITER" >> $GITHUB_ENV
+          if [ "$CABAL_COUNT" = 1 ]
+          then
+            echo "Bumping $CABAL_COUNT dependency" >> $GITHUB_ENV
+          else
+            echo "Bumping $CABAL_COUNT dependencies" >> $GITHUB_ENV
+          fi
+          echo "$DELIMITER" >> $GITHUB_ENV
+
+          echo "GIT_PR_BODY<<$DELIMITER" >> $GITHUB_ENV
+          echo '```' >> $GITHUB_ENV
+          echo "$CABAL_OUTDATED" >> $GITHUB_ENV
+          echo '```' >> $GITHUB_ENV
+          echo >> $GITHUB_ENV
+          echo "(Close and reopen this PR to trigger CI checks.)" >> $GITHUB_ENV
+          echo "$DELIMITER" >> $GITHUB_ENV
+
+          echo "GIT_COMMIT_MESSAGE<<$DELIMITER" >> $GITHUB_ENV
+          if [ "$CABAL_COUNT" = 1 ]
+          then
+            echo "Bumping $CABAL_COUNT dependency" >> $GITHUB_ENV
+          else
+            echo "Bumping $CABAL_COUNT dependencies" >> $GITHUB_ENV
+          fi
+          echo "" >> $GITHUB_ENV
+          cabal outdated >> $GITHUB_ENV
+          echo "$DELIMITER" >> $GITHUB_ENV
+
+
+      - name: Build
+        if: env.CABAL_COUNT > 0
+        shell: bash
+        run: |
+          cabal build --enable-tests --write-ghc-environment-files=always ${{ env.CABAL_FLAGS }}
+          cabal test ${{ env.CABAL_FLAGS }}
+
+      - name: Fetch cabal-plan-bounds
+        if: env.CABAL_COUNT > 0
+        shell: bash
+        run: |
+          curl -L https://github.com/nomeata/cabal-plan-bounds/releases/latest/download/cabal-plan-bounds.linux.gz | gunzip  > /usr/local/bin/cabal-plan-bounds
+          chmod +x /usr/local/bin/cabal-plan-bounds
+
+      - name: Update .cabal file
+        if: env.CABAL_COUNT > 0
+        shell: bash
+        run: |
+          # This line was added just for servant-swagger-ui, and counter-acts the default
+          cd ..
+
+          cabal-plan-bounds --extend dist-newstyle/cache/plan.json -c *.cabal
+          git diff *.cabal
+
+      - name: Create Pull Request
+        id: cpr
+        if: env.CABAL_COUNT > 0
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: "cabal-updates"
+          title: ${{ env.GIT_PR_TITLE }}
+          body: ${{ env.GIT_PR_BODY }}
+          commit-message: ${{ env.GIT_COMMIT_MESSAGE }}
+          delete-branch: true
+          add-paths: |
+            servant-swagger-ui-core/*.cabal
+
+      - name: Link to Pull Requst from summary
+        if: env.CABAL_COUNT > 0 && steps.cpr.outputs.pull-request-number
+        shell: bash
+        run: |
+          # This line was added just for servant-swagger-ui, and counter-acts the default
+          cd ..
+
+          echo "See [pull request ${{ steps.cpr.outputs.pull-request-number }}](${{ steps.cpr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -94,7 +94,7 @@ jobs:
         if: env.CABAL_COUNT > 0
         shell: bash
         run: |
-          cabal build --dependencies only --enable-tests --write-ghc-environment-files=always ${{ env.CABAL_FLAGS }}
+          cabal build --only-dependencies --enable-tests --write-ghc-environment-files=always ${{ env.CABAL_FLAGS }}
 
       - name: Build local package
         if: env.CABAL_COUNT > 0


### PR DESCRIPTION
The deps bumper doesn't work out of the box, so we inline it and apply some customizations:

* It doesn't support multiple packages, so we modify it to only do ui-core
* It fails the action when dependencies fail to bump with allow-newer, which is undesirable right now since servant is expected to not work with aeson-2.2. Looks like [a new operator might get added](https://discourse.haskell.org/t/the-operator-in-cabal-files/6938/5?u=janus).

Note that it will still fail to bump bytestring if aeson can't be bumped for servant. But when all dependencies work with these two, it should be able to make a PR for it. And since it repeats every week, that should eventually happen.