### PR TITLE
Allow file-embed-lzma-0.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -4,10 +4,3 @@ packages:
   servant-swagger-ui-example/
   servant-swagger-ui-jensoleg/
   servant-swagger-ui-redoc/
-
-if impl(ghc >= 9.8) && impl(ghc < 9.10)
-  -- https://github.com/GetShopTV/swagger2/pull/255
-  allow-newer: swagger2:Cabal
-  allow-newer: swagger2:base-compat-batteries
-  allow-newer: swagger2:lens
-  allow-newer: swagger2:network

--- a/servant-swagger-ui-jensoleg/servant-swagger-ui-jensoleg.cabal
+++ b/servant-swagger-ui-jensoleg/servant-swagger-ui-jensoleg.cabal
@@ -88,7 +88,7 @@ library
       base             >=4.7      && <4.21
     , aeson            >=0.8.0.2  && <2.3
     , bytestring       >=0.10.4.0 && <0.13
-    , file-embed-lzma  >=0        && <0.1
+    , file-embed-lzma  >=0        && <0.2
     , servant          >=0.14     && <0.21
     , servant-server   >=0.14     && <0.21
     , text             >=1.2.3.0  && <2.2

--- a/servant-swagger-ui-jensoleg/src/Servant/Swagger/UI/JensOleG.hs
+++ b/servant-swagger-ui-jensoleg/src/Servant/Swagger/UI/JensOleG.hs
@@ -58,7 +58,11 @@ import Servant.Swagger.UI.Core
 import Data.Aeson      (ToJSON, Value)
 import Data.ByteString (ByteString)
 import Data.Text       (Text)
+#if MIN_VERSION_file_embed_lzma(0,1,0)
+import FileEmbedLzma.Untyped
+#else
 import FileEmbedLzma
+#endif
 import Servant
 
 -- | Serve alternative Swagger UI.

--- a/servant-swagger-ui-redoc/servant-swagger-ui-redoc.cabal
+++ b/servant-swagger-ui-redoc/servant-swagger-ui-redoc.cabal
@@ -42,7 +42,7 @@ library
       base             >=4.7      && <4.21
     , aeson            >=0.8.0.2  && <2.3
     , bytestring       >=0.10.4.0 && <0.13
-    , file-embed-lzma  >=0        && <0.1
+    , file-embed-lzma  >=0        && <0.2
     , servant          >=0.14     && <0.21
     , servant-server   >=0.14     && <0.21
     , text             >=1.2.3.0  && <2.2

--- a/servant-swagger-ui-redoc/src/Servant/Swagger/UI/ReDoc.hs
+++ b/servant-swagger-ui-redoc/src/Servant/Swagger/UI/ReDoc.hs
@@ -60,7 +60,11 @@ import Servant.Swagger.UI.Core
 import Data.Aeson      (ToJSON, Value)
 import Data.ByteString (ByteString)
 import Data.Text       (Text)
+#if MIN_VERSION_file_embed_lzma(0,1,0)
+import FileEmbedLzma.Untyped
+#else
 import FileEmbedLzma
+#endif
 import Servant
 
 -- | Serve alternative Swagger UI.

--- a/servant-swagger-ui/servant-swagger-ui.cabal
+++ b/servant-swagger-ui/servant-swagger-ui.cabal
@@ -58,7 +58,7 @@ library
       base             >=4.7      && <4.21
     , aeson            >=0.8.0.2  && <2.3
     , bytestring       >=0.10.4.0 && <0.13
-    , file-embed-lzma  >=0        && <0.1
+    , file-embed-lzma  >=0        && <0.2
     , servant          >=0.14     && <0.21
     , servant-server   >=0.14     && <0.21
     , text             >=1.2.3.0  && <2.2

--- a/servant-swagger-ui/src/Servant/Swagger/UI.hs
+++ b/servant-swagger-ui/src/Servant/Swagger/UI.hs
@@ -65,7 +65,11 @@ import Servant.Swagger.UI.Core
 import Data.Aeson      (ToJSON, Value)
 import Data.ByteString (ByteString)
 import Data.Text       (Text)
+#if MIN_VERSION_file_embed_lzma(0,1,0)
+import FileEmbedLzma.Untyped
+#else
 import FileEmbedLzma
+#endif
 import Servant
 
 -- | Serve Swagger UI on @/dir@ using @api@ as a Swagger spec source.


### PR DESCRIPTION
In contrast to #115, this only allows the new version of file-embed-lzma.
